### PR TITLE
fix(): set correct main to allow requiring the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stencil/utils",
   "version": "0.0.4",
   "description": "Dev tools to improve cross platform experiences.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "bin": {
     "sd": "./bin/sd"
   },


### PR DESCRIPTION
To allow using the lib directly in node, like:
`const stencilUtils = require('@stencil/utils');`